### PR TITLE
Fix relative link to csharp.Tests README in main README.md

### DIFF
--- a/csharp/README.md
+++ b/csharp/README.md
@@ -84,7 +84,7 @@ dotnet restore
 dotnet test --logger "console;verbosity=detailed
 ```
 
-For more details, see the [csharp.Tests/README.md](csharp.Tests/README.md).
+For more details, see the [csharp.Tests/README.md](../csharp.Tests/README.md).
 
 ## 📚 Features
 


### PR DESCRIPTION
Fix relative link to csharp.Tests README in main README.md

- Updated the link from [csharp.Tests/README.md](csharp.Tests/README.md) to [csharp.Tests/README.md](../csharp.Tests/README.md)
- Ensures correct navigation to the test project README from main README
